### PR TITLE
Add port binding for services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: postgres:11-alpine
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
     environment:
       POSTGRES_DB: 'manifold_production'
       POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -11,6 +13,8 @@ services:
       - network1
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.6.7
+    ports:
+      - "9200:9200"
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       xpack.security.enabled: 'false'
@@ -20,6 +24,8 @@ services:
     image: redis:alpine
     volumes:
       - ./data/redis:/data
+    ports:
+      - "6379:6379"
     networks:
       - network1
   api_cable:
@@ -45,6 +51,8 @@ services:
     command: ["./start-and-run", "bin/zhong zhong.rb"]
   api_rails:
     image: manifoldscholar/manifold_api_rails:${MANIFOLD_TAG}
+    ports:
+      - "3020:3020"
     volumes:
       - ./data/api/public:/opt/manifold/api/public
       - ./data/sockets:/manifold_sockets


### PR DESCRIPTION
Adds port binding for the following services:

- Postgres
- ElasticSearch
- Redis
- API-Rails

Facilitates usage of this Docker-Compose file as part of a Dev workspace.